### PR TITLE
Support techzone CE pattern

### DIFF
--- a/installapp/tz-build-images-code-engine.sh
+++ b/installapp/tz-build-images-code-engine.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+echo "************************************"
+echo " Display parameter"
+echo "************************************"
+echo ""
+echo "Parameter count : $@"
+echo "Parameter zero 'name of the script': $0"
+echo "---------------------------------"
+echo "Service catalog image        : $1"
+echo "Frontend image               : $2"
+echo "Registry URL                 : $3"
+echo "Build CE Project             : $4"
+echo "Registry Secret Name         : $5"
+echo "---------------------------------"
+echo ""
+
+# **************** Global variables
+export SERVICE_CATALOG_IMAGE=$1
+export FRONTEND_IMAGE=$2
+export REGISTRY_URL=$3
+export PROJECT_NAME=$4
+export SECRET_NAME=$5
+
+export ROOT_PROJECT=multi-tenancy
+export FRONTEND_SOURCEFOLDER=multi-tenancy-frontend
+export BACKEND_SOURCEFOLDER=multi-tenancy-backend
+
+
+# **********************************************************************************
+# Functions
+# **********************************************************************************
+
+setROOT_PATH() {
+   echo "************************************"
+   echo " Set ROOT_PATH"
+   echo "************************************"
+   cd ../../
+   export ROOT_PATH=$(pwd)
+   echo "Path: $ROOT_PATH"
+}
+
+setupCRenvCE() {
+   
+   IBMCLOUDCLI_KEY_NAME="cliapikey_for_multi_tenant_$PROJECT_NAME"
+   IBMCLOUDCLI_KEY_DESCRIPTION="CLI APIkey $IBMCLOUDCLI_KEY_NAME"
+   CLIKEY_FILE="cli_key.json"
+   USERNAME="iamapikey"
+   
+   RESULT=$(ibmcloud iam api-keys | grep '$IBMCLOUDCLI_KEY_NAME' | awk '{print $1;}' | head -n 1)
+   echo "API key: $RESULT"
+   if [[ $RESULT == $IBMCLOUDCLI_KEY_NAME ]]; then
+        echo "*** The Cloud API key '$IBMCLOUDCLI_KEY_NAME' already exists !"
+        echo "*** The script 'ce-install-application.sh' ends here!"
+        echo "*** Review your existing API keys 'https://cloud.ibm.com/iam/apikeys'."
+        exit 1
+   fi
+
+   ibmcloud iam api-key-create $IBMCLOUDCLI_KEY_NAME -d "My IBM CLoud CLI API key for project $PROJECT_NAME" --file $CLIKEY_FILE
+   CLIAPIKEY=$(cat $CLIKEY_FILE | grep '"apikey":' | awk '{print $2;}' | sed 's/"//g' | sed 's/,//g' )
+   #echo $CLIKEY
+   rm -f $CLIKEY_FILE
+
+   ibmcloud ce project select --name $PROJECT_NAME
+   
+   ibmcloud ce registry create --name $SECRET_NAME \
+                               --server $REGISTRY_URL \
+                               --username $USERNAME \
+                               --password $CLIAPIKEY
+}
+
+buildBackend() {
+    echo "************************************"
+    echo " Backend $SERVICE_CATALOG_IMAGE"
+    echo "************************************"
+    cd $ROOT_PATH/$BACKEND_SOURCEFOLDER
+
+    # ibmcloud iam oauth-tokens | sed -ne '/IAM token/s/.* //p' | buildah login -u iambearer --password-stdin $REGISTRY_URL
+
+    # buildah bud -t "$SERVICE_CATALOG_IMAGE" -f Dockerfile .
+    # buildah push "$SERVICE_CATALOG_IMAGE"
+
+    ibmcloud ce buildrun submit --name service-catalog --image $SERVICE_CATALOG_IMAGE \
+                                --registry-secret $SECRET_NAME --source .
+
+    ibmcloud ce buildrun logs -f -n service-catalog
+    echo ""
+}
+
+buildFrontend() {
+    echo "************************************"
+    echo " Frontend $FRONTEND_IMAGE"
+    echo "************************************"
+    cd $ROOT_PATH/$FRONTEND_SOURCEFOLDER
+
+    # ibmcloud iam oauth-tokens | sed -ne '/IAM token/s/.* //p' | buildah login -u iambearer --password-stdin $REGISTRY_URL
+
+    # buildah bud -t "$FRONTEND_IMAGE" -f Dockerfile .
+    # buildah push "$FRONTEND_IMAGE"
+
+    ibmcloud ce buildrun submit --name frontend-image --image $FRONTEND_IMAGE \
+                                --registry-secret $SECRET_NAME --source .
+    
+    ibmcloud ce buildrun logs -f -n frontend-image
+    echo ""
+}
+
+resetPath() {
+   echo "************************************"
+   echo " Reset path"
+   echo "************************************"
+   cd $ROOT_PATH/$ROOT_PROJECT
+   echo ""
+}
+
+
+# **********************************************************************************
+# Execution
+# **********************************************************************************
+
+setROOT_PATH
+setupCRenvCE
+buildBackend
+buildFrontend
+resetPath

--- a/installapp/tz-check-prerequisites.sh
+++ b/installapp/tz-check-prerequisites.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+# **************** Global variables
+
+export CHECK_IBMCLOUDCLI="ibmcloud"
+export CHECK_JQ="jq-"
+export CHECK_SED="sed"
+export CHECK_AWK="mawk:"
+export CHECK_CURL="curl"
+export CHECK_KUBECTL="Client"
+export CHECK_PLUGIN_CLOUDDATABASES="cloud-databases"
+export CHECK_PLUGIN_CODEENGINE="code-engine"
+export CHECK_PLUGIN_CONTAINERREGISTERY="container-registry"
+export CHECK_GREP="grep"
+export CHECK_LIBPQ="psql"
+
+export VERICATION=""
+
+
+# **********************************************************************************
+# Functions definition
+# **********************************************************************************
+
+verifyLibpq() {  
+    VERICATION=$(psql --version)
+
+    if [[ $VERICATION =~ $CHECK_LIBPQ ]]; then
+    echo "- libpq (psql) is installed: $VERICATION !"
+    else 
+    echo "*** libpq (psql) is NOT installed !"
+    echo "*** The scripts ends here!"
+    exit 1
+    fi
+}
+
+verifyGrep() {  
+    VERICATION=$(grep --version)
+
+    if [[ $VERICATION =~ $CHECK_GREP  ]]; then
+    echo "- Grep is installed: $VERICATION !"
+    else 
+    echo "*** Grep is NOT installed !"
+    echo "*** The scripts ends here!"
+    exit 1
+    fi
+}
+
+verifyCURL() {  
+    VERICATION=$(curl --version)
+
+    if [[ $VERICATION =~ $CHECK_CURL  ]]; then
+    echo "- cURL is installed: $VERICATION !"
+    else 
+    echo "*** cURL is NOT installed !"
+    echo "*** The scripts ends here!"
+    exit 1
+    fi
+}
+
+verifyAWK() {  
+    VERICATION=$(mawk -W)
+
+    if [[ $VERICATION =~ $CHECK_AWK  ]]; then
+    echo "- AWK is installed: $VERICATION !"
+    else 
+    echo "*** AWK is NOT installed !"
+    echo "*** The scripts ends here!"
+    exit 1
+    fi
+}
+
+verifySed() {  
+    VERICATION=$(sed --version)
+
+    if [[ $VERICATION =~ $CHECK_SED  ]]; then
+    echo "- Sed is installed: $VERICATION !"
+    else 
+    echo "*** Sed is NOT installed !"
+    echo "*** The scripts ends here!"
+    exit 1
+    fi
+}
+
+verifyIBMCloudCLI() {  
+    VERICATION=$(ibmcloud --version)
+
+    if [[ $VERICATION =~ $CHECK_IBMCLOUDCLI  ]]; then
+    echo "- IBM Cloud CLI is installed: $VERICATION !"
+    else 
+    echo "*** IBM Cloud CLI is NOT installed !"
+    echo "*** The scripts ends here!"
+    exit 1
+    fi
+}
+
+verifyJQ() {
+    VERICATION=$(jq --version)
+
+    if [[ $VERICATION =~ $CHECK_JQ  ]]; then
+    echo "- JQ is installed: $VERICATION !"
+    else 
+    echo "*** JQ is NOT installed !"
+    echo "*** The scripts ends here!"
+    exit 1
+    fi
+}
+
+verifyIBMCloudPluginCloudDatabases() {
+    VERICATION=$(ibmcloud plugin show cloud-databases | grep 'Plugin Name' |  awk '{print $3}' )
+
+    if [[ $VERICATION =~ $CHECK_PLUGIN_CLOUDDATABASES  ]]; then
+    echo "- IBM Cloud Plugin 'cloud-databases' is installed: $VERICATION !"
+    else 
+    echo "IBM Cloud Plugin 'cloud-databases' is NOT installed !"
+    echo "*** The scripts ends here!"
+    exit 1
+    fi
+}
+
+verifyIBMCloudPluginCodeEngine() {
+    VERICATION=$(ibmcloud plugin show code-engine | grep 'Plugin Name' |  awk '{print $3}' )
+
+    if [[ $VERICATION =~ $CHECK_PLUGIN_CODEENGINE  ]]; then
+    echo "- IBM Cloud Plugin 'code-engine' is installed: $VERICATION !"
+    else 
+    echo "IBM Cloud Plugin 'code-engine' is NOT installed !"
+    echo "*** The scripts ends here!"
+    exit 1
+    fi
+}
+
+verifyIBMCloudPluginContainerRegistry() {
+    VERICATION=$(ibmcloud plugin show container-registry | grep 'Plugin Name' |  awk '{print $3}' )
+
+    if [[ $VERICATION =~ $CHECK_PLUGIN_CONTAINERREGISTERY  ]]; then
+    echo "- IBM Cloud Plugin 'container-registry' is installed: $VERICATION !"
+    else 
+    echo "IBM Cloud Plugin 'container-registry' is NOT installed !"
+    echo "*** The scripts ends here!"
+    exit 1
+    fi
+}
+
+verifyKubectl() {  
+    VERICATION=$(kubectl version)
+
+    if [[ $VERICATION =~ $CHECK_KUBECTL ]]; then
+    echo "- kubectl is installed: $VERICATION !"
+    else 
+    echo "*** kubectl is NOT installed !"
+    echo "*** The scripts ends here!"
+    exit 1
+    fi
+}
+
+# **********************************************************************************
+# Execution
+# **********************************************************************************
+
+echo "Check prereqisites"
+echo "1. Verify grep"
+verifyGrep
+echo "2. Verify awk"
+# verifyAWK
+echo "3. Verify cURL"
+verifyCURL
+echo "4. Verify Sed"
+verifySed
+echo "5. Verify jq"
+verifyJQ
+echo "6. Verify libpq (psql)"
+verifyLibpq
+echo "7. Verify ibmcloud cli"
+verifyIBMCloudCLI
+echo "8. Verify ibmcloud plugin cloud-databases"
+verifyIBMCloudPluginCloudDatabases
+echo "9. Verify ibmcloud plugin code-engine"
+verifyIBMCloudPluginCodeEngine
+echo "10. Verify ibmcloud plugin container-registry"
+verifyIBMCloudPluginContainerRegistry
+echo "11. Verify kubectl"
+verifyKubectl
+
+echo "Success! All prerequisites verified!"

--- a/installapp/tz-create-two-tenancies.sh
+++ b/installapp/tz-create-two-tenancies.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# CLI Documentation
+# ================
+# command documentation: https://cloud.ibm.com/docs/codeengine?topic=codeengine-cli#cli-application-create
+
+# Install jq to extract json in bash on mac
+# ===============
+# brew install jq
+
+# **************** Global variables
+
+# Configurations
+export GLOBAL="../configuration/global.json"
+export TENANT_A="../configuration/tenants/tenant-a.json"
+export TENANT_B="../configuration/tenants/tenant-b.json"
+
+# ecommerce application container image names
+export REGISTRY_URL=$(cat ./$GLOBAL | jq '.REGISTRY.URL' | sed 's/"//g')
+export IMAGE_TAG=$(cat ./$GLOBAL | jq '.REGISTRY.TAG' | sed 's/"//g')
+export NAMESPACE=$(cat ./$GLOBAL | jq '.REGISTRY.NAMESPACE' | sed 's/"//g')
+export FRONTEND_IMAGE_NAME=$(cat ./$GLOBAL | jq '.IMAGES.NAME_FRONTEND' | sed 's/"//g')
+export BACKEND_IMAGE_NAME=$(cat ./$GLOBAL | jq '.IMAGES.NAME_BACKEND' | sed 's/"//g')
+export FRONTEND_IMAGE="$REGISTRY_URL/$NAMESPACE/$FRONTEND_IMAGE_NAME:$IMAGE_TAG"
+export SERVICE_CATALOG_IMAGE="$REGISTRY_URL/$NAMESPACE/$BACKEND_IMAGE_NAME:$IMAGE_TAG"
+
+# Registry settings
+# ibm cloud  container registry settings
+export IBMCLOUD_CR_NAMESPACE=$(cat ./$GLOBAL | jq '.REGISTRY.NAMESPACE' | sed 's/"//g')
+export IBMCLOUD_CR_REGION_URL=$(cat ./$GLOBAL | jq '.REGISTRY.URL' | sed 's/"//g')
+export IBMCLOUD_CR_TAG=$(cat ./$GLOBAL | jq '.REGISTRY.TAG' | sed 's/"//g')
+export IBMCLOUD_CR_SECRET_NAME=$(cat ./$GLOBAL | jq -r '.REGISTRY.SECRET_NAME' | sed 's/"//g')
+
+# IBM Cloud target
+export RESOURCE_GROUP=$(cat ./$GLOBAL | jq -r '.IBM_CLOUD.RESOURCE_GROUP')
+export REGION=$(cat ./$GLOBAL | jq -r '.IBM_CLOUD.REGION')
+# Code Engine
+export IBMCLOUD_CE_BUILD_PROJECT=$(cat ./$TENANT_A | jq -r '.CODE_ENGINE.PROJECT_NAME') 
+
+# **********************************************************************************
+# Functions definition
+# **********************************************************************************
+# FYI: https://stackoverflow.com/questions/12468889/bash-script-error-function-not-found-why-would-this-appear
+
+configLogin() {
+     
+    echo "IBMCLOUD_CR_NAMESPACE: $IBMCLOUD_CR_NAMESPACE"
+    echo "RESOURCE_GROUP       : $RESOURCE_GROUP"
+    echo "REGION               : $REGION"
+    echo "------------------------------"
+    echo "Verify the given entries and press return"
+    
+    read input
+
+    ibmcloud target -g $RESOURCE_GROUP
+    ibmcloud target -r $REGION
+    ibmcloud target
+
+}
+
+createIBMContainer () {
+ 
+    echo "FRONTEND_IMAGE: $FRONTEND_IMAGE"
+    echo "SERVICE_CATALOG_IMAGE: $SERVICE_CATALOG_IMAGE"
+    echo "IBMCLOUD_CR_REGION_URL: $IBMCLOUD_CR_REGION_URL"
+    echo "IBMCLOUD_CE_BUILD_PROJECT: $IBMCLOUD_CE_BUILD_PROJECT"
+
+    # createNamespaceBuildah
+    
+    bash ./tz-build-images-code-engine.sh $SERVICE_CATALOG_IMAGE $FRONTEND_IMAGE $IBMCLOUD_CR_REGION_URL \
+                                          $IBMCLOUD_CE_BUILD_PROJECT $IBMCLOUD_CR_SECRET_NAME
+    
+    if [ $? == "1" ]; then
+      echo "*** Creation of the container images failed !"
+      echo "*** The script 'tz-create-two-tenancies.sh' ends here!"
+      exit 1
+    fi
+}
+
+# **********************************************************************************
+# Execution
+# **********************************************************************************
+
+echo "************************************"
+echo " Create container image in IBM Container Registry"
+echo "************************************"
+
+configLogin
+createIBMContainer
+
+echo "************************************"
+echo " Tenant A"
+echo "************************************"
+
+bash ./tz-install-application.sh $GLOBAL $TENANT_A skip-cr-secret
+
+if [ $? == "1" ]; then
+  echo "*** The installation for '$GLOBAL' '$TENANT_A' configuation failed !"
+  echo "*** The script 'tz-create-two-tenancies.sh' ends here!"
+  exit 1
+fi
+
+echo "************************************"
+echo " Tenant B"
+echo "************************************"
+
+bash ./tz-install-application.sh $GLOBAL $TENANT_B
+
+if [ $? == "1" ]; then
+  echo "*** The installation for '$GLOBAL' '$TENANT_B' configuation failed !"
+  echo "*** The script 'tz-create-two-tenancies.sh' ends here!"
+  exit 1
+fi

--- a/installapp/tz-install-application.sh
+++ b/installapp/tz-install-application.sh
@@ -1,0 +1,754 @@
+#!/bin/bash
+
+# CLI tools Documentation
+# ================
+# Code Engine: https://cloud.ibm.com/docs/codeengine?topic=codeengine-cli#cli-application-create
+# Cloud databases
+# IBM Cloud Container Registry 
+
+# Needed IBM Cloud CLI plugins
+# =============
+# - code engine 
+# - cloud databases (ibmcloud plugin install cloud-databases)
+# - container registry 
+
+# Needed tools 
+# ============
+# For Postgres database
+# - brew install libpq
+# - brew link --force libpq
+# Install jq to extract json in bash on mac
+# - brew install jq
+
+# **********************************************************************************
+# Set global variables using parameters
+# **********************************************************************************
+
+echo "************************************"
+echo " Display parameter"
+echo "************************************"
+echo ""
+echo "Parameter count : $@"
+echo "Parameter zero 'name of the script': $0"
+echo "---------------------------------"
+echo "Global configuration         : $1"
+echo "Tenant configuration         : $2"
+echo "Skip CR secret               : $3"
+echo "---------------------------------"
+
+# **************** Global variables set by parameters
+
+# Global config
+# --------------
+# IBM Cloud Container Registry
+export IBM_CR_SERVER=$(cat ./$1 | jq '.REGISTRY.URL' | sed 's/"//g')
+# CE for IBM Cloud Container Registry access
+export SECRET_NAME=$(cat ./$1 | jq '.REGISTRY.SECRET_NAME' | sed 's/"//g')
+export IBMCLOUDCLI_KEY_NAME="cliapikey_for_multi_tenant_$PROJECT_NAME"
+export REGISTRY_URL=$(cat ./$1 | jq '.REGISTRY.URL' | sed 's/"//g')
+export IBM_CR_SERVER=$REGISTRY_URL
+export IMAGE_TAG=$(cat ./$1 | jq '.REGISTRY.TAG' | sed 's/"//g')
+export NAMESPACE=$(cat ./$1 | jq '.REGISTRY.NAMESPACE' | sed 's/"//g')
+# IBM Cloud target
+export RESOURCE_GROUP=$(cat ./$1 | jq '.IBM_CLOUD.RESOURCE_GROUP' | sed 's/"//g')
+export REGION=$(cat ./$1 | jq '.IBM_CLOUD.REGION' | sed 's/"//g')
+# ecommerce application container registry
+export FRONTEND_IMAGE_NAME=$(cat ./$1 | jq '.IMAGES.NAME_FRONTEND' | sed 's/"//g')
+export BACKEND_IMAGE_NAME=$(cat ./$1 | jq '.IMAGES.NAME_BACKEND' | sed 's/"//g')
+export FRONTEND_IMAGE="$REGISTRY_URL/$NAMESPACE/$FRONTEND_IMAGE_NAME:$IMAGE_TAG"
+export SERVICE_CATALOG_IMAGE="$REGISTRY_URL/$NAMESPACE/$BACKEND_IMAGE_NAME:$IMAGE_TAG"
+
+# Tenant config
+# --------------
+# Code Engine
+export PROJECT_NAME=$(cat ./$2 | jq '.CODE_ENGINE.PROJECT_NAME' | sed 's/"//g') 
+# postgres
+export POSTGRES_SERVICE_INSTANCE=$(cat ./$2 | jq '.POSTGRES.SERVICE_INSTANCE' | sed 's/"//g') 
+export POSTGRES_SERVICE_KEY_NAME=$(cat ./$2 | jq '.POSTGRES.SERVICE_KEY_NAME' | sed 's/"//g')
+export POSTGRES_SQL_FILE=$(cat ./$2 | jq '.POSTGRES.SQL_FILE' | sed 's/"//g')
+# ecommerce application names
+export SERVICE_CATALOG_NAME=$(cat ./$2 | jq '.APPLICATION.CONTAINER_NAME_BACKEND' | sed 's/"//g')
+export FRONTEND_NAME=$(cat ./$2 | jq '.APPLICATION.CONTAINER_NAME_FRONTEND' | sed 's/"//g')
+export FRONTEND_CATEGORY=$(cat ./$2 | jq '.APPLICATION.CATEGORY' | sed 's/"//g')
+# App ID
+export APPID_SERVICE_INSTANCE_NAME=$(cat ./$2 | jq '.APP_ID.SERVICE_INSTANCE' | sed 's/"//g')
+export APPID_SERVICE_KEY_NAME=$(cat ./$2 | jq '.APP_ID.SERVICE_KEY_NAME' | sed 's/"//g')
+
+
+echo "Code Engine project              : $PROJECT_NAME"
+echo "---------------------------------"
+echo "App ID service instance name     : $APPID_SERVICE_INSTANCE_NAME"
+echo "App ID service key name          : $APPID_SERVICE_KEY_NAME"
+echo "---------------------------------"
+echo "Application Service Catalog name : $SERVICE_CATALOG_NAME"
+echo "Application Frontend name        : $FRONTEND_NAME"
+echo "Application Frontend category    : $FRONTEND_CATEGORY"
+echo "Application Service Catalog image: $SERVICE_CATALOG_IMAGE"
+echo "Application Frontend image       : $FRONTEND_IMAGE"
+echo "---------------------------------"
+echo "Postgres instance name           : $POSTGRES_SERVICE_INSTANCE"
+echo "Postgres service key name        : $POSTGRES_SERVICE_KEY_NAME"
+echo "Postgres sample data sql         : $POSTGRES_SQL_FILE"
+echo "---------------------------------"
+echo "IBM Cloud Container Registry URL : $IBM_CR_SERVER"
+echo "---------------------------------"
+echo "IBM Cloud RESOURCE_GROUP         : $RESOURCE_GROUP"
+echo "IBM Cloud REGION                 : $REGION"
+echo "---------------------------------"
+echo ""
+echo "------------------------------"
+echo "Verify parameters and press return"
+read input
+
+# **************** Global variables set as default values
+export NAMESPACE=""
+export STATUS="Running"
+export SECRET_NAME="multi.tenancy.cr.sec"
+export EMAIL=thomas@example.com
+
+# ecommerce application URLs
+export FRONTEND_URL=""
+export SERVICE_CATALOG_URL=""
+
+# AppID Service
+export SERVICE_PLAN="graduated-tier"
+export APPID_SERVICE_NAME="appid"
+export APPID_SERVICE_KEY_ROLE="Manager"
+export TENANTID=""
+export MANAGEMENTURL=""
+export APPLICATION_DISCOVERYENDPOINT=""
+
+# AppID User
+export USER_IMPORT_FILE="appid-configs/user-import.json"
+export USER_EXPORT_FILE="appid-configs/user-export.json"
+export ENCRYPTION_SECRET="12345678"
+
+# AppID Application configuration
+export ADD_APPLICATION="appid-configs/add-application.json"
+export ADD_SCOPE="appid-configs/add-scope.json"
+export ADD_ROLE="appid-configs/add-roles.json"
+export ADD_REDIRECT_URIS="appid-configs/add-redirecturis.json"
+export ADD_UI_TEXT="appid-configs/add-ui-text.json"
+export ADD_IMAGE="appid-images/logo.png"
+export ADD_COLOR="appid-configs/add-ui-color.json"
+export APPLICATION_CLIENTID=""
+export APPLICATION_TENANTID=""
+export APPLICATION_OAUTHSERVERURL=""
+
+# Postgres Service
+export POSTGRES_SERVICE_NAME=databases-for-postgresql
+export POSTGRES_PLAN=standard
+export POSTGRES_CONFIG_FOLDER="postgres-config"
+
+# Postgres database defaults
+export POSTGRES_CERTIFICATE_DATA=""
+export POSTGRES_USERNAME=""
+export POSTGRES_PASSWORD=""
+export POSTGRES_URL=""
+
+# **********************************************************************************
+# Functions definition
+# **********************************************************************************
+
+setupCLIenvCE() {
+  echo "**********************************"
+  echo " Using following project: $PROJECT_NAME" 
+  echo "**********************************"
+
+  ibmcloud target -g $RESOURCE_GROUP
+  ibmcloud target -r $REGION
+
+  # ibmcloud ce project create --name $PROJECT_NAME 
+
+  RESULT=$(ibmcloud ce project get --name $PROJECT_NAME | grep "Status" |  awk '{print $2;}')
+  if [[ $RESULT == "soft" ]]; then
+        echo "*** The project $PROJECT_NAME was deleted."
+        echo "*** The script 'ce-install-application.sh' ends here!"
+        echo "*** Review your 'tenant-xx.json' configuration file."
+        exit 1
+  fi
+  ibmcloud ce project select -n $PROJECT_NAME
+  
+  #to use the kubectl commands
+  ibmcloud ce project select -n $PROJECT_NAME --kubecfg
+  
+  NAMESPACE=$(ibmcloud ce project get --name $PROJECT_NAME --output json | grep "namespace" | awk '{print $2;}' | sed 's/"//g' | sed 's/,//g')
+  echo "Namespace: $NAMESPACE"
+  kubectl get pods -n $NAMESPACE
+
+  CHECK=$(ibmcloud ce project get -n $PROJECT_NAME | awk '/Apps/ {print $2;}')
+  echo "**********************************"
+  echo "Check for existing apps? '$CHECK'"
+  echo "**********************************"
+  if [[ $CHECK != "0" ]];then
+    echo "Error: There are remaining '$CHECK' apps in the Code Engine project."
+    echo "Wait until all apps are deleted inside project '$PROJECT_NAME'."
+    echo "The script exits here!"
+    exit 1
+  fi
+}
+
+setupCRenvCE() {
+   
+   IBMCLOUDCLI_KEY_NAME="cliapikey_for_multi_tenant_$PROJECT_NAME"
+   IBMCLOUDCLI_KEY_DESCRIPTION="CLI APIkey $IBMCLOUDCLI_KEY_NAME"
+   CLIKEY_FILE="cli_key.json"
+   USERNAME="iamapikey"
+   
+   RESULT=$(ibmcloud iam api-keys | grep '$IBMCLOUDCLI_KEY_NAME' | awk '{print $1;}' | head -n 1)
+   echo "API key: $RESULT"
+   if [[ $RESULT == $IBMCLOUDCLI_KEY_NAME ]]; then
+        echo "*** The Cloud API key '$IBMCLOUDCLI_KEY_NAME' already exists !"
+        echo "*** The script 'ce-install-application.sh' ends here!"
+        echo "*** Review your existing API keys 'https://cloud.ibm.com/iam/apikeys'."
+        exit 1
+   fi
+
+   ibmcloud iam api-key-create $IBMCLOUDCLI_KEY_NAME -d "My IBM CLoud CLI API key for project $PROJECT_NAME" --file $CLIKEY_FILE
+   CLIAPIKEY=$(cat $CLIKEY_FILE | grep '"apikey":' | awk '{print $2;}' | sed 's/"//g' | sed 's/,//g' )
+   #echo $CLIKEY
+   rm -f $CLIKEY_FILE
+
+   ibmcloud ce registry create --name $SECRET_NAME \
+                               --server $IBM_CR_SERVER \
+                               --username $USERNAME \
+                               --password $CLIAPIKEY \
+                               --email $EMAIL
+}
+
+# **** Postgres ****
+
+createPostgres () {
+    echo ""
+    echo "+++++++++++++++++++++++++"
+    echo "Create postgres instance"
+    echo "+++++++++++++++++++++++++"
+    echo ""
+    
+    # ***** Get instance ID
+    echo ""
+    echo "-------------------------"
+    echo "Get instance ID"
+    echo "-------------------------"
+    echo ""
+    POSTGRES_INSTANCE_ID=$(ibmcloud resource service-instance $POSTGRES_SERVICE_INSTANCE --id | tail -1 | awk '{print $1;}')
+    echo "Postgres instance ID: $POSTGRES_INSTANCE_ID"
+
+    # **** Create service key and get the postgres connection
+    echo ""
+    echo "-------------------------"
+    echo "Create service key and get the postgres connection"
+    echo "-------------------------"
+    echo ""
+
+    # **** Create a service key for the service
+    # ibmcloud resource service-key-create $POSTGRES_SERVICE_KEY_NAME --instance-id $POSTGRES_INSTANCE_ID
+}
+
+extractPostgresConfiguration () {
+    echo ""
+    echo "+++++++++++++++++++++++++"
+    echo "Extract postgres configuration"
+    echo "+++++++++++++++++++++++++"
+    echo ""
+    # ***** Get service key of the service
+    ibmcloud resource service-key $POSTGRES_SERVICE_KEY_NAME --output JSON > ./postgres-config/postgres-key-temp.json  
+
+    # ***** Extract needed configuration of the service key
+
+    POSTGRES_CERTIFICATE_CONTENT_ENCODED=$(cat ./$POSTGRES_CONFIG_FOLDER/postgres-key-temp.json | jq '.[].credentials.connection.cli.certificate.certificate_base64' | sed 's/"//g' ) 
+    POSTGRES_USERNAME=$(cat ./$POSTGRES_CONFIG_FOLDER/postgres-key-temp.json | jq '.[].credentials.connection.postgres.authentication.username' | sed 's/"//g' )
+    POSTGRES_PASSWORD=$(cat ./$POSTGRES_CONFIG_FOLDER/postgres-key-temp.json | jq '.[].credentials.connection.postgres.authentication.password' | sed 's/"//g' )
+    POSTGRES_HOST=$(cat ./$POSTGRES_CONFIG_FOLDER/postgres-key-temp.json | jq '.[].credentials.connection.postgres.hosts[].hostname' | sed 's/"//g' )
+    POSTGRES_PORT=$(cat ./$POSTGRES_CONFIG_FOLDER/postgres-key-temp.json | jq '.[].credentials.connection.postgres.hosts[].port' | sed 's/"//g' )
+
+    # ***** Build needed cert content format  
+    echo "$POSTGRES_CERTIFICATE_CONTENT_ENCODED" | base64 -d > ./$POSTGRES_CONFIG_FOLDER/cert.temp
+    POSTGRES_CERTIFICATE_DATA=$(<./$POSTGRES_CONFIG_FOLDER/cert.temp)
+    rm -f ./"$POSTGRES_CONFIG_FOLDER"/cert.temp
+
+    # ***** Build postgres URL
+    CONNECTION_TYPE='jdbc:postgresql://'
+    CERTIFICATE_PATH='/cloud-postgres-cert'
+    DATABASE_NAME="ibmclouddb"
+    POSTGRES_URL="$CONNECTION_TYPE$POSTGRES_HOST:$POSTGRES_PORT/$DATABASE_NAME?sslmode=verify-full&sslrootcert=$CERTIFICATE_PATH"
+
+    # ***** Delete temp file    
+    rm -f ./"$POSTGRES_CONFIG_FOLDER"/postgres-key-temp.json
+    
+    # ***** verfy variables
+    echo "-------------------------"
+    echo "POSTGRES_CERTIFICATE_DATA:  $POSTGRES_CERTIFICATE_DATA"
+    echo "POSTGRES_USERNAME:          $POSTGRES_USERNAME"
+    echo "POSTGRES_PASSWORD:          $POSTGRES_PASSWORD"
+    echo "POSTGRES_URL     :          $POSTGRES_URL"
+    echo "-------------------------"
+
+}
+
+createTablesPostgress () {
+    echo ""
+    echo "+++++++++++++++++++++++++"
+    echo "Create table in postgres"
+    echo "+++++++++++++++++++++++++"
+    echo ""
+    
+    echo ""
+    echo "-------------------------"
+    echo "Get the postgres connection statement"
+    echo "-------------------------"
+    echo ""   
+    # ***** Get service key of the service
+    ibmcloud resource service-key $POSTGRES_SERVICE_KEY_NAME --output JSON > ./postgres-config/postgres-key-temp.json
+    POSTGRES_CONNECTION_TEMP=$(cat ./postgres-config/postgres-key-temp.json | jq '.[].credentials.connection.cli.composed[]' | sed 's/"//g' | sed '$ s/.$//' )
+    rm -f ./"$POSTGRES_CONFIG_FOLDER"/postgres-key-temp.json
+    echo ""
+    echo "-------------------------"
+    echo "Prepare postgres connection command: $POSTGRES_CONNECTION_TEMP"
+    echo "-------------------------"
+    export POSTGRES_CONNECTION="$POSTGRES_CONNECTION_TEMP' -a -f $POSTGRES_SQL_FILE"
+    echo ""
+    echo "-------------------------"
+    echo "Postgres connection command: [$POSTGRES_CONNECTION]" 
+    echo "-------------------------"
+    
+    # **** Get cert
+    echo ""
+    echo "-------------------------"
+    echo "Get certificate"
+    echo "-------------------------"
+    echo ""  
+    cd $POSTGRES_CONFIG_FOLDER
+    echo "-------------------------"
+    echo "Current path"
+    pwd
+    # **** Create a tmp folder for the 'postgres_cert'
+    TMP_FOLDER=postgres_temp_cert
+    mkdir $TMP_FOLDER
+    cd $TMP_FOLDER
+    echo "-------------------------"
+    echo "Temp path"
+    pwd
+    ibmcloud cdb deployment-cacert $POSTGRES_SERVICE_INSTANCE \
+                                    --save \
+                                    --certroot .
+
+    # **** Get connection to postgres with cert
+    echo "-------------------------"
+    echo "Get connection to postgres with cert"
+    echo "-------------------------"
+    echo ""
+    ibmcloud cdb deployment-connections "$POSTGRES_SERVICE_INSTANCE" \
+                                        --certroot . 
+    # **** Copy needed sql script
+    cp ../"$POSTGRES_SQL_FILE" ./"$POSTGRES_SQL_FILE"
+    # **** Create bash script
+    sed "s+COMMAND_INSERT+$POSTGRES_CONNECTION+g" "../insert-template.sh" > ./insert.sh
+    # **** Execute the bash script with the extracted format
+    echo "-------------------------"
+    echo "Create table in postgres using ($POSTGRES_SQL_FILE)"
+    echo "-------------------------"
+    echo ""
+    cat insert.sh
+    echo "------------------------------"
+    echo "Verify the given entries and press return"
+    echo "------------------------------"
+    bash insert.sh
+    cd ..
+    echo "-------------------------"
+    echo "Clean up"
+    pwd
+    # **** Clean-up the temp folder and content
+    rm -f -r ./$TMP_FOLDER
+    cd ..
+    echo "-------------------------"
+    echo "Done"
+    pwd
+}
+
+# **** AppID ****
+
+createAppIDService() {
+    ibmcloud target -g $RESOURCE_GROUP
+    ibmcloud target -r $REGION
+    # Get the tenantId of the AppID service key
+    TENANTID=$(ibmcloud resource service-keys --instance-name $APPID_SERVICE_INSTANCE_NAME --output json | grep "tenantId" | awk '{print $2;}' | sed 's/"//g')
+    echo "Tenant ID: $TENANTID"
+    # Get the managementUrl of the AppID from service key
+    MANAGEMENTURL=$(ibmcloud resource service-keys --instance-name $APPID_SERVICE_INSTANCE_NAME --output json | grep "managementUrl" | awk '{print $2;}' | sed 's/"//g' | sed 's/,//g')
+    echo "Management URL: $MANAGEMENTURL"
+}
+
+configureAppIDInformation(){
+
+    #****** Set identity providers
+    echo ""
+    echo "-------------------------"
+    echo " Set identity providers"
+    echo "-------------------------"
+    echo ""
+    OAUTHTOKEN=$(ibmcloud iam oauth-tokens | awk '{print $4;}')
+    result=$(curl -d @./appid-configs/idps-custom.json -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $OAUTHTOKEN" $MANAGEMENTURL/config/idps/custom)
+    echo ""
+    echo "-------------------------"
+    echo "Result custom: $result"
+    echo "-------------------------"
+    echo ""
+    OAUTHTOKEN=$(ibmcloud iam oauth-tokens | awk '{print $4;}')
+    result=$(curl -d @./appid-configs/idps-facebook.json -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $OAUTHTOKEN" $MANAGEMENTURL/config/idps/facebook)
+    echo ""
+    echo "-------------------------"
+    echo "Result facebook: $result"
+    echo "-------------------------"
+    echo ""
+    OAUTHTOKEN=$(ibmcloud iam oauth-tokens | awk '{print $4;}')
+    result=$(curl -d @./appid-configs/idps-google.json -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $OAUTHTOKEN" $MANAGEMENTURL/config/idps/google)
+    echo ""
+    echo "-------------------------"
+    echo "Result google: $result"
+    echo "-------------------------"
+    echo ""
+    OAUTHTOKEN=$(ibmcloud iam oauth-tokens | awk '{print $4;}')
+    result=$(curl -d @./appid-configs/idps-clouddirectory.json -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $OAUTHTOKEN" $MANAGEMENTURL/config/idps/cloud_directory)
+    echo ""
+    echo "-------------------------"
+    echo "Result cloud directory: $result"
+    echo "-------------------------"
+    echo ""
+
+    #****** Add application ******
+    echo ""
+    echo "-------------------------"
+    echo " Create application"
+    echo "-------------------------"
+    echo ""
+    sed "s+FRONTENDNAME+$FRONTEND_NAME+g" ./appid-configs/add-application-template.json > ./$ADD_APPLICATION
+    result=$(curl -d @./$ADD_APPLICATION -H "Content-Type: application/json" -H "Authorization: Bearer $OAUTHTOKEN" $MANAGEMENTURL/applications)
+    echo "-------------------------"
+    echo "Result application: $result"
+    echo "-------------------------"
+    APPLICATION_CLIENTID=$(echo $result | sed -n 's|.*"clientId":"\([^"]*\)".*|\1|p')
+    APPLICATION_TENANTID=$(echo $result | sed -n 's|.*"tenantId":"\([^"]*\)".*|\1|p')
+    APPLICATION_OAUTHSERVERURL=$(echo $result | sed -n 's|.*"oAuthServerUrl":"\([^"]*\)".*|\1|p')
+    APPLICATION_DISCOVERYENDPOINT=$(echo $result | sed -n 's|.*"discoveryEndpoint":"\([^"]*\)".*|\1|p')
+    echo "ClientID: $APPLICATION_CLIENTID"
+    echo "TenantID: $APPLICATION_TENANTID"
+    echo "oAuthServerUrl: $APPLICATION_OAUTHSERVERURL"
+    echo "discoveryEndpoint: $APPLICATION_DISCOVERYENDPOINT"
+    echo ""
+
+    #****** Add scope ******
+    echo ""
+    echo "-------------------------"
+    echo " Add scope"
+    echo "-------------------------"
+    OAUTHTOKEN=$(ibmcloud iam oauth-tokens | awk '{print $4;}')
+    result=$(curl -d @./$ADD_SCOPE -H "Content-Type: application/json" -X PUT -H "Authorization: Bearer $OAUTHTOKEN" $MANAGEMENTURL/applications/$APPLICATION_CLIENTID/scopes)
+    echo "-------------------------"
+    echo "Result scope: $result"
+    echo "-------------------------"
+    echo ""
+
+    #****** Add role ******
+    echo "-------------------------"
+    echo " Add role"
+    echo "-------------------------"
+    #Create file from template
+    sed "s+APPLICATIONID+$APPLICATION_CLIENTID+g" ./appid-configs/add-roles-template.json > ./$ADD_ROLE
+    OAUTHTOKEN=$(ibmcloud iam oauth-tokens | awk '{print $4;}')
+    #echo $OAUTHTOKEN
+    result=$(curl -d @./$ADD_ROLE -H "Content-Type: application/json" -X POST -H "Authorization: Bearer $OAUTHTOKEN" $MANAGEMENTURL/roles)
+    rm -f ./$ADD_ROLE
+    echo "-------------------------"
+    echo "Result role: $result"
+    echo "-------------------------"
+    echo ""
+ 
+    #****** Import cloud directory users ******
+    echo ""
+    echo "-------------------------"
+    echo " Cloud directory import users"
+    echo "-------------------------"
+    echo ""
+    OAUTHTOKEN=$(ibmcloud iam oauth-tokens | awk '{print $4;}')
+    result=$(curl -d @./$USER_IMPORT_FILE -H "Content-Type: application/json" -X POST -H "Authorization: Bearer $OAUTHTOKEN" $MANAGEMENTURL/cloud_directory/import?encryption_secret=$ENCRYPTION_SECRET)
+    echo "-------------------------"
+    echo "Result import: $result"
+    echo "-------------------------"
+    echo ""
+
+    #******* Configure ui text  ******
+    echo ""
+    echo "-------------------------"
+    echo " Configure ui text"
+    echo "-------------------------"
+    echo ""
+    sed "s+FRONTENDNAME+$FRONTEND_NAME+g" ./appid-configs/add-ui-text-template.json > ./$ADD_UI_TEXT
+    OAUTHTOKEN=$(ibmcloud iam oauth-tokens | awk '{print $4;}')
+    echo "PUT url: $MANAGEMENTURL/config/ui/theme_txt"
+    result=$(curl -d @./$ADD_UI_TEXT -H "Content-Type: application/json" -X PUT -H "Authorization: Bearer $OAUTHTOKEN" $MANAGEMENTURL/config/ui/theme_text)
+    rm -f $ADD_UI_TEXT
+    echo "-------------------------"
+    echo "Result import: $result"
+    echo "-------------------------"
+    echo ""
+
+    #******* Configure ui color  ******
+    echo ""
+    echo "-------------------------"
+    echo " Configure ui color"
+    echo "-------------------------"
+    echo ""
+    OAUTHTOKEN=$(ibmcloud iam oauth-tokens | awk '{print $4;}')
+    echo "PUT url: $MANAGEMENTURL/config/ui/theme_color"
+    result=$(curl -d @./$ADD_COLOR -H "Content-Type: application/json" -X PUT -H "Authorization: Bearer $OAUTHTOKEN" $MANAGEMENTURL/config/ui/theme_color)
+    echo "-------------------------"
+    echo "Result import: $result"
+    echo "-------------------------"
+    echo ""
+
+    #******* Configure ui image  ******
+    echo ""
+    echo "-------------------------"
+    echo " Configure ui image"
+    echo "-------------------------"
+    echo ""
+    OAUTHTOKEN=$(ibmcloud iam oauth-tokens | awk '{print $4;}')
+    echo "POST url: $MANAGEMENTURL/config/ui/media?mediaType=logo"
+    result=$(curl -F "file=@./$ADD_IMAGE" -H "Content-Type: multipart/form-data" -X POST -v -H "Authorization: Bearer $OAUTHTOKEN" "$MANAGEMENTURL/config/ui/media?mediaType=logo")
+    echo "-------------------------"
+    echo "Result import: $result"
+    echo "-------------------------"
+    echo ""
+}
+
+addRedirectURIAppIDInformation(){
+
+    #****** Add redirect uris ******
+    echo ""
+    echo "-------------------------"
+    echo " Add redirect uris"
+    echo "-------------------------"
+    echo ""
+    OAUTHTOKEN=$(ibmcloud iam oauth-tokens | awk '{print $4;}')
+    echo "Redirect URL: $FRONTEND_URL"
+    #Create file from template
+    sed "s+APPLICATION_REDIRECT_URL+$FRONTEND_URL+g" ./appid-configs/add-redirecturis-template.json > ./$ADD_REDIRECT_URIS
+    result=$(curl -d @./$ADD_REDIRECT_URIS -H "Content-Type: application/json" -X PUT -H "Authorization: Bearer $OAUTHTOKEN" $MANAGEMENTURL/config/redirect_uris)
+    rm -f ./$ADD_REDIRECT_URIS
+    echo "-------------------------"
+    echo "Result redirect uris: $result"
+    echo "-------------------------"
+    echo ""
+}
+
+# **** application and microservices ****
+
+createSecrets() {
+
+    echo "Create secrets" 
+    ibmcloud ce secret create --name postgres.certificate-data --from-literal "POSTGRES_CERTIFICATE_DATA=$POSTGRES_CERTIFICATE_DATA"
+    ibmcloud ce secret create --name postgres.username --from-literal "POSTGRES_USERNAME=$POSTGRES_USERNAME"
+    ibmcloud ce secret create --name postgres.password --from-literal "POSTGRES_PASSWORD=$POSTGRES_PASSWORD"
+    ibmcloud ce secret create --name postgres.url --from-literal "POSTGRES_URL=$POSTGRES_URL"
+    ibmcloud ce secret create --name appid.oauthserverurl --from-literal "APPID_AUTH_SERVER_URL=$APPLICATION_OAUTHSERVERURL"
+    ibmcloud ce secret create --name appid.client-id-catalog-service  --from-literal "APPID_CLIENT_ID=$APPLICATION_CLIENTID"
+    ibmcloud ce secret create --name appid.client-id-fronted  --from-literal "VUE_APPID_CLIENT_ID=$APPLICATION_CLIENTID"
+    ibmcloud ce secret create --name appid.discovery-endpoint --from-literal "VUE_APPID_DISCOVERYENDPOINT=$APPLICATION_DISCOVERYENDPOINT"
+
+}
+
+deployServiceCatalog(){
+    
+    ibmcloud ce application create --name $SERVICE_CATALOG_NAME \
+                                   --image $SERVICE_CATALOG_IMAGE \
+                                   --env-from-secret postgres.certificate-data \
+                                   --env-from-secret postgres.username \
+                                   --env-from-secret postgres.password \
+                                   --env-from-secret postgres.url \
+                                   --env-from-secret appid.oauthserverurl \
+                                   --env-from-secret appid.client-id-catalog-service \
+                                   --cpu "1" \
+                                   --memory "2G" \
+                                   --port 8081 \
+                                   --registry-secret "$SECRET_NAME" \
+                                   --max-scale 1 \
+                                   --min-scale 0 
+                                       
+    SERVICE_CATALOG_URL=$(ibmcloud ce application get --name "$SERVICE_CATALOG_NAME" -o url)
+    echo "Set SERVICE CATALOG URL: $SERVICE_CATALOG_URL"
+}
+
+deployFrontend(){
+    
+    ibmcloud ce application create --name $FRONTEND_NAME \
+                                   --image $FRONTEND_IMAGE \
+                                   --cpu "1" \
+                                   --memory "2G" \
+                                   --env-from-secret appid.client-id-fronted \
+                                   --env-from-secret appid.discovery-endpoint \
+                                   --env VUE_APP_API_URL_PRODUCTS="$SERVICE_CATALOG_URL/base/category" \
+                                   --env VUE_APP_API_URL_ORDERS="$SERVICE_CATALOG_URL/base/customer/Orders" \
+                                   --env VUE_APP_API_URL_CATEGORIES="$SERVICE_CATALOG_URL/base/category" \
+                                   --env VUE_APP_CATEGORY_NAME="$FRONTEND_CATEGORY" \
+                                   --env VUE_APP_HEADLINE="$FRONTEND_NAME" \
+                                   --env VUE_APP_ROOT="/" \
+                                   --registry-secret "$SECRET_NAME" \
+                                   --max-scale 1 \
+                                   --min-scale 0 \
+                                   --port 8080 
+
+    ibmcloud ce application get --name $FRONTEND_NAME
+    FRONTEND_URL=$(ibmcloud ce application get --name "$FRONTEND_NAME" -o url)
+    echo "Set FRONTEND URL: $FRONTEND_URL"
+}
+
+# **** Kubernetes CLI ****
+
+kubeDeploymentVerification(){
+
+    echo "************************************"
+    echo " pods, deployments and configmaps details "
+    echo "************************************"
+    
+    kubectl get pods -n $NAMESPACE
+    kubectl get deployments -n $NAMESPACE
+    kubectl get configmaps -n $NAMESPACE
+
+}
+
+getKubeContainerLogs(){
+
+    echo "************************************"
+    echo " $FRONTEND_NAME log"
+    echo "************************************"
+
+    FIND="$FRONTEND_NAME"
+    FRONTEND_LOG=$(kubectl get pod -n $NAMESPACE | grep $FIND | awk '{print $1}')
+    echo $FRONTEND_LOG
+    kubectl logs $FRONTEND_LOG user-container
+
+    echo "************************************"
+    echo " $SERVICE_CATALOG_NAME logs"
+    echo "************************************"
+
+    FIND=$SERVICE_CATALOG_NAME
+    SERVICE_CATALOG_LOG=$(kubectl get pod -n $NAMESPACE | grep $FIND | awk '{print $1}')
+    echo $SERVICE_CATALOG_LOG
+    kubectl logs $SERVICE_CATALOG_LOG user-container
+
+}
+
+checkKubernetesPod (){
+    application_pod="${1}" 
+
+    array=("$application_pod")
+    for i in "${array[@]}"
+    do 
+        echo ""
+        echo "------------------------------------------------------------------------"
+        echo "Check $i"
+        while :
+        do
+            FIND=$i
+            STATUS_CHECK=$(kubectl get pod -n $NAMESPACE | grep $FIND | awk '{print $3}')
+            echo "Status: $STATUS_CHECK"
+            if [ "$STATUS" = "$STATUS_CHECK" ]; then
+                echo "$(date +'%F %H:%M:%S') Status: $FIND is Ready"
+                echo "------------------------------------------------------------------------"
+                break
+            else
+                echo "$(date +'%F %H:%M:%S') Status: $FIND($STATUS_CHECK)"
+                echo "------------------------------------------------------------------------"
+            fi
+            sleep 5
+        done
+    done
+}
+
+# **********************************************************************************
+# Execution
+# **********************************************************************************
+
+echo "************************************"
+echo " CLI config"
+echo "************************************"
+
+setupCLIenvCE
+
+echo "************************************"
+echo " Configure container registry access"
+echo "************************************"
+
+if [ -z "$3" ]; then
+  setupCRenvCE
+fi
+
+echo "************************************"
+echo " Create Postgres instance and database"
+echo "************************************"
+
+createPostgres
+createTablesPostgress
+extractPostgresConfiguration
+
+echo "************************************"
+echo " AppID creation"
+echo "************************************"
+
+createAppIDService
+
+echo "************************************"
+echo " AppID configuration"
+echo "************************************"
+
+configureAppIDInformation
+
+echo "************************************"
+echo " Create secrets"
+echo "************************************"
+
+createSecrets
+
+echo "************************************"
+echo " service catalog"
+echo "************************************"
+
+deployServiceCatalog
+ibmcloud ce application events --application $SERVICE_CATALOG_NAME
+
+echo "************************************"
+echo " frontend"
+echo "************************************"
+
+deployFrontend
+ibmcloud ce application events --application $FRONTEND_NAME
+
+echo "************************************"
+echo " AppID add redirect URI"
+echo "************************************"
+
+addRedirectURIAppIDInformation
+
+echo "************************************"
+echo " Verify deployments"
+echo "************************************"
+
+kubeDeploymentVerification
+
+echo "************************************"
+echo " Container logs"
+echo "************************************"
+
+getKubeContainerLogs
+
+echo "************************************"
+echo " URLs"
+echo "************************************"
+echo " - oAuthServerUrl   : $APPLICATION_OAUTHSERVERURL"
+echo " - discoveryEndpoint: $APPLICATION_DISCOVERYENDPOINT"
+echo " - Frontend         : $FRONTEND_URL"
+echo " - ServiceCatalog   : $SERVICE_CATALOG_URL"
+echo "------------------------------"
+echo "Verify the given entries and press return"
+echo "------------------------------"

--- a/installapp/tz-update-config.sh
+++ b/installapp/tz-update-config.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# **********************************************************************************
+# Set global variables using parameters
+# **********************************************************************************
+
+echo "************************************"
+echo " Display parameter"
+echo "************************************"
+echo ""
+echo "Parameter count : $@"
+echo "Parameter zero 'name of the script': $0"
+echo "---------------------------------"
+echo "Code Engine Region           : $1"
+echo "Container Registry Namespace : $2"
+echo "Resource Group Name          : $3"
+echo "---------------------------------"
+
+export REGION=${REGION:-${1}}
+export NAMESPACE=${NAMESPACE:-${2}}
+export RESOURCE_GROUP=${RESOURCE_GROUP:-${3}}
+export RANDOM8=$(echo ${NAMESPACE} | cut -f3 -d"-")
+
+# Configurations
+export GLOBAL="../configuration/global.json"
+export TENANT_A="../configuration/tenants/tenant-a.json"
+export TENANT_B="../configuration/tenants/tenant-b.json"
+
+# **********************************************************************************
+# Determine host for Container Registry based on region
+# **********************************************************************************
+
+case $REGION in
+  us-south)
+    export REGISTRY_URL=us.icr.io 
+    ;;
+  ca-tor)
+    export REGISTRY_URL=ca.icr.io
+    ;;
+  eu-gb)
+    export REGISTRY_URL=uk.icr.io
+    ;;
+  eu-de)
+    export REGISTRY_URL=de.icr.io
+    ;;
+  jp-tok)
+    export REGISTRY_URL=jp.icr.io
+    ;;
+  au-syd)
+    export REGISTRY_URL=au.icr.io
+    ;;
+esac 
+
+# **********************************************************************************
+# Update global configuration properties
+# **********************************************************************************
+
+sed -i.bak "s/default/${RESOURCE_GROUP}/" ${GLOBAL} && rm ${GLOBAL}.bak
+sed -i.bak "s/eu-de/${REGION}/" ${GLOBAL} && rm ${GLOBAL}.bak
+sed -i.bak "s/de\.icr\.io/${REGISTRY_URL}/" ${GLOBAL} && rm ${GLOBAL}.bak
+sed -i.bak "s/multi-tenancy-example/${NAMESPACE}/" ${GLOBAL} && rm ${GLOBAL}.bak
+
+# **********************************************************************************
+# Update Tenant A configuration properties
+# **********************************************************************************
+
+sed -i.bak "s/multi-tenancy-serverless-appid-a/${NAMESPACE}-00/" ${TENANT_A}&& rm ${TENANT_A}.bak
+sed -i.bak "s/itzce/appid/" ${TENANT_A}&& rm ${TENANT_A}.bak
+sed -i.bak "s/multi-tenancy-serverless-appid-key-a/appid-service-key-${RANDOM8}-00/" ${TENANT_A}&& rm ${TENANT_A}.bak
+sed -i.bak "s/multi-tenancy-serverless-pg-ten-a-key/pgsql-service-key-${RANDOM8}-00/" ${TENANT_A}&& rm ${TENANT_A}.bak
+sed -i.bak "s/multi-tenancy-serverless-pg-ten-a/${NAMESPACE}-00/" ${TENANT_A}&& rm ${TENANT_A}.bak
+sed -i.bak "s/itzce/pgsql/" ${TENANT_A}&& rm ${TENANT_A}.bak
+sed -i.bak "s/multi-tenancy-serverless-a/${NAMESPACE}-00/" ${TENANT_A}&& rm ${TENANT_A}.bak
+
+# **********************************************************************************
+# Update Tenant B configuration properties
+# **********************************************************************************
+
+sed -i.bak "s/multi-tenancy-serverless-appid-b/${NAMESPACE}-01/" ${TENANT_B}&& rm ${TENANT_B}.bak
+sed -i.bak "s/itzce/appid/" ${TENANT_B}&& rm ${TENANT_B}.bak
+sed -i.bak "s/multi-tenancy-serverless-appid-key-b/appid-service-key-${RANDOM8}-01/" ${TENANT_B}&& rm ${TENANT_B}.bak
+sed -i.bak "s/multi-tenancy-serverless-pg-ten-b-key/pgsql-service-key-${RANDOM8}-01/" ${TENANT_B}&& rm ${TENANT_B}.bak
+sed -i.bak "s/multi-tenancy-serverless-pg-ten-b/${NAMESPACE}-01/" ${TENANT_B}&& rm ${TENANT_B}.bak
+sed -i.bak "s/itzce/pgsql/" ${TENANT_B}&& rm ${TENANT_B}.bak
+sed -i.bak "s/multi-tenancy-serverless-b/${NAMESPACE}-01/" ${TENANT_B}&& rm ${TENANT_B}.bak


### PR DESCRIPTION
Adds scripts for creating two tenant environment from TechZone reservation (prefixed with `tz-`):

- script to update config files for global and tenants from values from reservation
- remove buildah from pre-req check
- use first (tenant A) code engine project as build environment for container images
- scripts tested in Cloud Shell
- do not create appid, postgres as these are created in techzone reservation